### PR TITLE
Remove underline and change 'copied' prompt to last for 1 second fore…

### DIFF
--- a/RESTular.js
+++ b/RESTular.js
@@ -13,8 +13,8 @@ $(document).ready(function() {
       $(event.target).addClass(".on-click")
       setTimeout(function(){
         $(event.target).siblings(".copy-prompt").text("^click to copy^");
-        $(event.target).addClass(".on-click")
-      }, 10000);
+        $(event.target).addClass(".on-click");
+      }, 1000);
     });
   });
 

--- a/RESTular.js
+++ b/RESTular.js
@@ -40,18 +40,18 @@ $(document).ready(function() {
 
     var rand100 = Math.floor(Math.random() * 100)
     if (rand100 === 69) {
-      $('.sub-box-under').text("Rest-a-licious!")
-    } else if (rand100 >= 80) {
-      $('.sub-box-under').text("Type something in!")
-    } else if (rand100 >= 60) {
-        $('.sub-box-under').text("Try your own!")
-    } else if (rand100 >= 40) {
-        $('.sub-box-under').text("Chi Bobolinks 2015!")
-    } else if (rand100 >= 20) {
-        $('.sub-box-under').text("Rapid Restful Results! (TM)")
-    } else {
-        $('.sub-box-under').text("Kitchen it? Kitchen it.")
-    }
+      $('.sub-box-under').text("Chi Bobolinks 2015!")
+    } //else if (rand100 >= 80) {
+    //   $('.sub-box-under').text("Type something in!")
+    // } else if (rand100 >= 60) {
+    //     $('.sub-box-under').text("Try your own!")
+    // } else if (rand100 >= 40) {
+    //     $('.sub-box-under').text("Rest-a-licious!")
+    // } else if (rand100 >= 20) {
+    //     $('.sub-box-under').text("Rapid Restful Results! (TM)")
+    // } else {
+    //     $('.sub-box-under').text("Kitchen it? Kitchen it.")
+    // }
   });
 
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 		</form>
 	</div>
 
-	<div class="sub-box-under">(<b><u>Type in your table name</u></b> and <b><u>click table</u></b> for full route info)</div>
+	<div class="sub-box-under">(Type in your table name and <b>click table</b> for full route info)</div>
 
 	<div id="route-container">
 		<table>


### PR DESCRIPTION
… improved usability

@farmanp I changed the underline thanks for pointing that out.. CSS sins are not good ;) 

I changed the copied alert to only last for 1 second. Check it out and tell me if that's any better. I could also change it to only say 'copied' on the latest thing you copied. 

I'm not sure exactly what you were asking about the params thing... like if someone puts in a table name that doesn't follow restful conventions (eg. 'createdog'  or 'Cats' or 'user info') it might pop up and say (error: Invalid table name containing space, or capital letter ect.)?
